### PR TITLE
Go back to focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.6_10-jre-jammy@sha256:f2e5fa11c16cd41da0433bab513790b0c9f95071675ad1a8e853aaaa3e0db6af
+FROM eclipse-temurin:17.0.6_10-jre-focal@sha256:b10df4660e02cf944260b13182e4815fc3e577ba510de7f4abccc797e93d9106
 
 # Download and install wkhtmltopdf
 RUN apt-get update \
@@ -11,9 +11,10 @@ RUN apt-get update \
     libx11-6 \
     libxrender1 \
     libjpeg-turbo8 \
+    libssl1.1 \
     && apt-get clean
 
-RUN curl "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb" -L -o "wkhtmltopdf.deb" \
+RUN curl "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb" -L -o "wkhtmltopdf.deb" \
     && dpkg -i ./wkhtmltopdf.deb \
     && apt-get install -f \
     && rm -rf wkhtmlto*


### PR DESCRIPTION
This PR changes the Dockerfile to use a temurin image that is based on `focal` instead of `jammy`.
For compatibility reasons `wkhtmltopdf` is downgraded from `0.12.6.1` to `0.12.6`.
This does not change much, as the changes are [very minor](https://github.com/wkhtmltopdf/wkhtmltopdf/commit/c61ecdeed13b8e001f77c4a2b4050d0c732e9e72).